### PR TITLE
feat(candidate): Implement Candidate Management API

### DIFF
--- a/src/main/java/com/abdulkhaleel/blockchain_voting/BlockchainVotingApplication.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/BlockchainVotingApplication.java
@@ -3,12 +3,12 @@ package com.abdulkhaleel.blockchain_voting;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
-@EntityScan(basePackages = {
-		"com.abdulkhaleel.blockchain_voting.election.model",
-		"com.abdulkhaleel.blockchain_voting.user.model"
-})
+@EntityScan("com.abdulkhaleel.blockchain_voting")
+@EnableJpaRepositories("com.abdulkhaleel.blockchain_voting")
+
 public class BlockchainVotingApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/abdulkhaleel/blockchain_voting/candidate/controller/CandidateController.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/candidate/controller/CandidateController.java
@@ -1,0 +1,61 @@
+package com.abdulkhaleel.blockchain_voting.candidate.controller;
+
+import com.abdulkhaleel.blockchain_voting.candidate.dto.CandidateRequest;
+import com.abdulkhaleel.blockchain_voting.candidate.dto.CandidateResponse;
+import com.abdulkhaleel.blockchain_voting.candidate.services.CandidateService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class CandidateController {
+    private final CandidateService candidateService;
+
+    @PostMapping("/elections/{electionId}/candidates")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<CandidateResponse> addCandidate(@PathVariable Long electionId, @Valid @RequestBody CandidateRequest candidateRequest){
+        CandidateResponse newCandidate = candidateService.addCandidate(electionId, candidateRequest);
+        return new ResponseEntity<>(newCandidate, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/elections/{electionId}/candidates")
+    public ResponseEntity<List<CandidateResponse>> getCandidatesByElectionId(@PathVariable Long electionId){
+        List<CandidateResponse> candidates = candidateService.getCandidatesByElection(electionId);
+
+        return ResponseEntity.ok(candidates);
+    }
+
+    @GetMapping("/candidates/{candidateId}")
+    public ResponseEntity<CandidateResponse> getCandidateById(@PathVariable Long candidateId){
+        CandidateResponse candidate = candidateService.getCandidateById(candidateId);
+        return ResponseEntity.ok(candidate);
+    }
+
+    @PutMapping("/elections/{electionId}/candidates/{candidateId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<CandidateResponse> updateCandidate(
+            @PathVariable Long electionId,
+            @PathVariable Long candidateId,
+            @Valid @RequestBody CandidateRequest candidateRequest){
+
+        CandidateResponse candidate = candidateService.updateCandidate(electionId, candidateId, candidateRequest);
+        return ResponseEntity.ok(candidate);
+    }
+
+    @DeleteMapping("/elections/{electionId}/candidates/{candidateId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Void> deleteCandidate(
+            @PathVariable Long electionId,
+            @PathVariable Long candidateId){
+
+        candidateService.deleteCandidate(electionId, candidateId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/abdulkhaleel/blockchain_voting/candidate/dto/CandidateRequest.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/candidate/dto/CandidateRequest.java
@@ -1,0 +1,19 @@
+package com.abdulkhaleel.blockchain_voting.candidate.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CandidateRequest {
+    @NotBlank(message = "Candidate name is required")
+    private String name;
+
+    @NotBlank(message = "Candidate party is required")
+    private String party;
+
+    private String manifesto;
+}

--- a/src/main/java/com/abdulkhaleel/blockchain_voting/candidate/dto/CandidateResponse.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/candidate/dto/CandidateResponse.java
@@ -1,0 +1,29 @@
+package com.abdulkhaleel.blockchain_voting.candidate.dto;
+
+import com.abdulkhaleel.blockchain_voting.candidate.model.Candidate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CandidateResponse {
+    private Long id;
+    private String name;
+    private String party;
+    private String manifesto;
+    private Long electionId;
+
+    public static CandidateResponse formEntity(Candidate candidate){
+        return CandidateResponse.builder()
+                .id(candidate.getId())
+                .name(candidate.getName())
+                .party(candidate.getParty())
+                .manifesto(candidate.getManifesto())
+                .electionId(candidate.getElection().getId())
+                .build();
+    }
+}

--- a/src/main/java/com/abdulkhaleel/blockchain_voting/candidate/model/Candidate.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/candidate/model/Candidate.java
@@ -1,0 +1,38 @@
+package com.abdulkhaleel.blockchain_voting.candidate.model;
+
+import com.abdulkhaleel.blockchain_voting.election.model.Election;
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import jakarta.persistence.*; // Make sure this import is present
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "candidates")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Candidate {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    @Column(nullable = false)
+    private String name;
+
+    @NotBlank
+    @Column(nullable = false)
+    private String party;
+
+    private String manifesto;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "election_id", nullable = false)
+    @JsonBackReference
+    private Election election;
+}

--- a/src/main/java/com/abdulkhaleel/blockchain_voting/candidate/repository/CandidateRepository.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/candidate/repository/CandidateRepository.java
@@ -1,0 +1,13 @@
+package com.abdulkhaleel.blockchain_voting.candidate.repository;
+
+import com.abdulkhaleel.blockchain_voting.candidate.model.Candidate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CandidateRepository extends JpaRepository<Candidate, Long> {
+    List<Candidate> findByElectionId(Long electionId);
+
+    Optional<Candidate> findByIdAndElectionId(Long id, Long electionId);
+}

--- a/src/main/java/com/abdulkhaleel/blockchain_voting/candidate/services/CandidateService.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/candidate/services/CandidateService.java
@@ -1,0 +1,14 @@
+package com.abdulkhaleel.blockchain_voting.candidate.services;
+
+import com.abdulkhaleel.blockchain_voting.candidate.dto.CandidateRequest;
+import com.abdulkhaleel.blockchain_voting.candidate.dto.CandidateResponse;
+
+import java.util.List;
+
+public interface CandidateService {
+    CandidateResponse addCandidate(Long electionId, CandidateRequest candidateRequest);
+    List<CandidateResponse> getCandidatesByElection(Long electionId);
+    CandidateResponse getCandidateById(Long candidateId);
+    CandidateResponse updateCandidate(Long electionId, Long candidateId, CandidateRequest candidateRequest);
+    void deleteCandidate(Long electionId, Long candidateId);
+}

--- a/src/main/java/com/abdulkhaleel/blockchain_voting/candidate/services/CandidateServiceImpl.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/candidate/services/CandidateServiceImpl.java
@@ -1,0 +1,83 @@
+package com.abdulkhaleel.blockchain_voting.candidate.services;
+
+import com.abdulkhaleel.blockchain_voting.candidate.dto.CandidateRequest;
+import com.abdulkhaleel.blockchain_voting.candidate.dto.CandidateResponse;
+import com.abdulkhaleel.blockchain_voting.candidate.model.Candidate;
+import com.abdulkhaleel.blockchain_voting.candidate.repository.CandidateRepository;
+import com.abdulkhaleel.blockchain_voting.election.model.Election;
+import com.abdulkhaleel.blockchain_voting.election.repository.ElectionRepository;
+import com.abdulkhaleel.blockchain_voting.exception.ResourceNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CandidateServiceImpl implements CandidateService{
+    private final ElectionRepository electionRepository;
+    private final CandidateRepository candidateRepository;
+
+    @Override
+    @Transactional
+    public CandidateResponse addCandidate(Long electionId, CandidateRequest candidateRequest){
+        Election election = electionRepository.findById(electionId)
+                .orElseThrow(() -> new ResourceNotFoundException("Election not found with the id: " + electionId));
+
+        Candidate candidate = Candidate.builder()
+                .name(candidateRequest.getName())
+                .party(candidateRequest.getParty())
+                .manifesto(candidateRequest.getManifesto())
+                .election(election)
+                .build();
+
+        Candidate savedCandidate = candidateRepository.save(candidate);
+
+        return CandidateResponse.formEntity(savedCandidate);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<CandidateResponse> getCandidatesByElection(Long electionId){
+        if(!electionRepository.existsById(electionId)){
+            throw new ResourceNotFoundException("Election not found with the id: "+ electionId);
+        }
+        return candidateRepository.findByElectionId(electionId).stream()
+                .map(CandidateResponse::formEntity)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CandidateResponse getCandidateById(Long candidateId){
+        Candidate candidate = candidateRepository.findById(candidateId)
+                .orElseThrow(() -> new ResourceNotFoundException("Candidate not found with id: " + candidateId));
+
+        return CandidateResponse.formEntity(candidate);
+    }
+
+    @Override
+    @Transactional
+    public CandidateResponse updateCandidate(Long electionId, Long candidateId, CandidateRequest candidateRequest){
+        Candidate candidate = candidateRepository.findByIdAndElectionId(candidateId, electionId)
+                .orElseThrow(() -> new ResourceNotFoundException("Candidate with id " + candidateId + "not found in the election " + electionId));
+
+        candidate.setName(candidateRequest.getName());
+        candidate.setParty(candidateRequest.getParty());
+        candidate.setManifesto(candidateRequest.getManifesto());
+
+        Candidate updatedCandidate = candidateRepository.save(candidate);
+        return CandidateResponse.formEntity(updatedCandidate);
+    }
+
+    @Override
+    @Transactional
+    public void deleteCandidate(Long electionId, Long candidateId){
+        Candidate candidate = candidateRepository.findByIdAndElectionId(candidateId, electionId)
+                .orElseThrow(() -> new ResourceNotFoundException("Candidate with id " + candidateId + "not found in the election " + electionId));
+
+        candidateRepository.delete(candidate);
+    }
+}

--- a/src/main/java/com/abdulkhaleel/blockchain_voting/config/WebSecurityConfig.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/config/WebSecurityConfig.java
@@ -60,8 +60,12 @@ public class WebSecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth ->
                         auth.requestMatchers("/api/auth/**", "/api/users/register").permitAll()
-                                .requestMatchers("/api/test/**", "/api/health", "/").permitAll()
-                                .requestMatchers(HttpMethod.GET, "/api/elections/**").permitAll()
+                                .requestMatchers(HttpMethod.GET,
+                                        "/api/elections",
+                                        "/api/elections/**",
+                                        "/api/candidates",
+                                        "/api/candidates/**"
+                                ).permitAll()
                                 .anyRequest().authenticated()
                 );
         http.authenticationProvider(authenticationProvider());

--- a/src/main/java/com/abdulkhaleel/blockchain_voting/election/model/Election.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/election/model/Election.java
@@ -1,11 +1,15 @@
 package com.abdulkhaleel.blockchain_voting.election.model;
 
+import com.abdulkhaleel.blockchain_voting.candidate.model.Candidate;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Table(name = "elections")
@@ -36,4 +40,8 @@ public class Election {
     private boolean allowRevote;
 
     private LocalDateTime createdAt = LocalDateTime.now();
+
+    @OneToMany(mappedBy = "election", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @JsonManagedReference
+    private Set<Candidate> candidates = new HashSet<>();
 }


### PR DESCRIPTION
- Adds Candidate entity with a ManyToOne relationship to Election.
- Updates Election entity with a OneToMany relationship to manage candidates.
- Creates CandidateRepository with custom queries.
- Implements CandidateService and DTOs for business logic and API contracts.
- Adds CandidateController with 5 CRUD endpoints for managing candidates within an election.
- Secures CUD endpoints for ADMIN role using @PreAuthorize.
- Fixes a PatternParseException in WebSecurityConfig by correcting wildcard usage for public GET endpoints.