### PR TITLE
feat(vote): Implement core user voting operations

### DIFF
--- a/src/main/java/com/abdulkhaleel/blockchain_voting/vote/controller/VoteController.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/vote/controller/VoteController.java
@@ -1,0 +1,49 @@
+package com.abdulkhaleel.blockchain_voting.vote.controller;
+
+import com.abdulkhaleel.blockchain_voting.security.services.UserDetailsImpl;
+import com.abdulkhaleel.blockchain_voting.user.dto.MessageResponse;
+import com.abdulkhaleel.blockchain_voting.vote.dto.CastVoteRequest;
+import com.abdulkhaleel.blockchain_voting.vote.dto.HasVotedResponse;
+import com.abdulkhaleel.blockchain_voting.vote.dto.VoteResponse;
+import com.abdulkhaleel.blockchain_voting.vote.service.VoteService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@CrossOrigin(origins = "*", maxAge = 3600)
+@RestController
+@RequestMapping("/api/votes")
+@RequiredArgsConstructor
+public class VoteController {
+    private final VoteService voteService;
+
+    @PostMapping
+    @PreAuthorize("hasRole('USER')")
+    public ResponseEntity<VoteResponse> casteVote(
+            @Valid @RequestBody CastVoteRequest castVoteRequest,
+            @AuthenticationPrincipal UserDetailsImpl currentUser){
+        VoteResponse voteResponse = voteService.castVote(castVoteRequest, currentUser);
+        return ResponseEntity.ok(voteResponse);
+    }
+
+    @GetMapping("/check/{electionId}")
+    @PreAuthorize("hasRole('USER')")
+    public ResponseEntity<HasVotedResponse> checkIfUserHasVoted(
+            @PathVariable Long electionId,
+            @AuthenticationPrincipal UserDetailsImpl currentUser){
+        HasVotedResponse response = voteService.checkIfVoted(electionId, currentUser);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{electionId}")
+    @PreAuthorize("hasRole('USER')")
+    public ResponseEntity<MessageResponse> retractVote(
+            @PathVariable Long electionId,
+            @AuthenticationPrincipal UserDetailsImpl currentUser){
+        MessageResponse response = voteService.refractVote(electionId, currentUser);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/abdulkhaleel/blockchain_voting/vote/dto/CastVoteRequest.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/vote/dto/CastVoteRequest.java
@@ -1,0 +1,13 @@
+package com.abdulkhaleel.blockchain_voting.vote.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class CastVoteRequest {
+    @NotNull(message = "Election ID is required")
+    private Long electionId;
+
+    @NotNull(message = "Candidate ID is required")
+    private Long candidateId;
+}

--- a/src/main/java/com/abdulkhaleel/blockchain_voting/vote/dto/HasVotedResponse.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/vote/dto/HasVotedResponse.java
@@ -1,0 +1,10 @@
+package com.abdulkhaleel.blockchain_voting.vote.dto;
+
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class HasVotedResponse {
+    private boolean hasVoted;
+}

--- a/src/main/java/com/abdulkhaleel/blockchain_voting/vote/dto/VoteResponse.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/vote/dto/VoteResponse.java
@@ -1,0 +1,15 @@
+package com.abdulkhaleel.blockchain_voting.vote.dto;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class VoteResponse {
+    private Long voteId;
+    private Long electionId;
+    private Long candidateId;
+    private Long voterId;
+    private LocalDateTime votedAt;
+    private String message;
+}

--- a/src/main/java/com/abdulkhaleel/blockchain_voting/vote/model/Vote.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/vote/model/Vote.java
@@ -1,0 +1,45 @@
+package com.abdulkhaleel.blockchain_voting.vote.model;
+
+import com.abdulkhaleel.blockchain_voting.candidate.model.Candidate;
+import com.abdulkhaleel.blockchain_voting.election.model.Election;
+import com.abdulkhaleel.blockchain_voting.user.model.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "votes",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"voter_id", "election_id"})
+        })
+public class Vote {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "voter_id", nullable = false)
+    private User voter;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "election_id", nullable = false)
+    private Election election;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "candidate_id", nullable = false)
+    private Candidate candidate;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime votedAt;
+}

--- a/src/main/java/com/abdulkhaleel/blockchain_voting/vote/repository/VoteRepository.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/vote/repository/VoteRepository.java
@@ -1,0 +1,10 @@
+package com.abdulkhaleel.blockchain_voting.vote.repository;
+
+import com.abdulkhaleel.blockchain_voting.vote.model.Vote;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface VoteRepository extends JpaRepository<Vote, Long> {
+    Optional<Vote> findByVoterIdAndElectionId(Long voterId, Long electionId);
+}

--- a/src/main/java/com/abdulkhaleel/blockchain_voting/vote/service/VoteService.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/vote/service/VoteService.java
@@ -1,0 +1,13 @@
+package com.abdulkhaleel.blockchain_voting.vote.service;
+
+import com.abdulkhaleel.blockchain_voting.security.services.UserDetailsImpl;
+import com.abdulkhaleel.blockchain_voting.user.dto.MessageResponse;
+import com.abdulkhaleel.blockchain_voting.vote.dto.CastVoteRequest;
+import com.abdulkhaleel.blockchain_voting.vote.dto.HasVotedResponse;
+import com.abdulkhaleel.blockchain_voting.vote.dto.VoteResponse;
+
+public interface VoteService {
+    VoteResponse castVote(CastVoteRequest castVoteRequest, UserDetailsImpl currentUser);
+    HasVotedResponse checkIfVoted(Long electionId, UserDetailsImpl currentUser);
+    MessageResponse refractVote(Long electionId, UserDetailsImpl currentUser);
+}

--- a/src/main/java/com/abdulkhaleel/blockchain_voting/vote/service/VoteServiceImpl.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/vote/service/VoteServiceImpl.java
@@ -1,0 +1,107 @@
+package com.abdulkhaleel.blockchain_voting.vote.service;
+
+import com.abdulkhaleel.blockchain_voting.candidate.model.Candidate;
+import com.abdulkhaleel.blockchain_voting.candidate.repository.CandidateRepository;
+import com.abdulkhaleel.blockchain_voting.election.model.Election;
+import com.abdulkhaleel.blockchain_voting.election.model.ElectionStatus;
+import com.abdulkhaleel.blockchain_voting.election.repository.ElectionRepository;
+import com.abdulkhaleel.blockchain_voting.exception.ResourceNotFoundException;
+import com.abdulkhaleel.blockchain_voting.security.services.UserDetailsImpl;
+import com.abdulkhaleel.blockchain_voting.user.dto.MessageResponse;
+import com.abdulkhaleel.blockchain_voting.user.model.User;
+import com.abdulkhaleel.blockchain_voting.user.repository.UserRepository;
+import com.abdulkhaleel.blockchain_voting.vote.dto.CastVoteRequest;
+import com.abdulkhaleel.blockchain_voting.vote.dto.HasVotedResponse;
+import com.abdulkhaleel.blockchain_voting.vote.dto.VoteResponse;
+import com.abdulkhaleel.blockchain_voting.vote.model.Vote;
+import com.abdulkhaleel.blockchain_voting.vote.repository.VoteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+
+@Service
+@RequiredArgsConstructor
+public class VoteServiceImpl implements VoteService{
+    private final UserRepository userRepository;
+    private final ElectionRepository electionRepository;
+    private final CandidateRepository candidateRepository;
+    private final VoteRepository voteRepository;
+
+    @Override
+    @Transactional
+    public VoteResponse castVote(CastVoteRequest castVoteRequest, UserDetailsImpl currentUser){
+        Long userId = currentUser.getId();
+
+        User voter = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found with the id: " + userId));
+
+        Election election = electionRepository.findById(castVoteRequest.getElectionId())
+                .orElseThrow(() -> new ResourceNotFoundException("Election not found with the id: " + castVoteRequest.getElectionId()));
+
+        Candidate candidate = candidateRepository.findById(castVoteRequest.getCandidateId())
+                .orElseThrow(() -> new ResourceNotFoundException("Candidate not found with the id: " + castVoteRequest.getCandidateId()));
+
+        if(election.getStatus() != ElectionStatus.ACTIVE){
+            throw new IllegalStateException("Voting is only allowed for the Active elections.");
+        }
+
+        if(!election.getEligibleVoters().contains(voter)){
+            throw new AccessDeniedException("You are not eligible to vote this election");
+        }
+
+        if(!Objects.equals(candidate.getElection().getId(), election.getId())){
+            throw new IllegalArgumentException("The selected candidate is not part of this election");
+        }
+
+        voteRepository.findByVoterIdAndElectionId(userId, election.getId())
+                .ifPresent(v -> {
+                    throw new IllegalStateException("You have already cast your vote in this election.");
+                });
+
+        Vote vote = Vote.builder()
+                .voter(voter)
+                .election(election)
+                .candidate(candidate)
+                .build();
+
+        Vote savedVote = (Vote) voteRepository.save(vote);
+
+        return VoteResponse.builder()
+                .voteId(savedVote.getId())
+                .voterId(savedVote.getVoter().getId())
+                .electionId(savedVote.getElection().getId())
+                .candidateId(savedVote.getCandidate().getId())
+                .votedAt(savedVote.getVotedAt())
+                .message("Vote casted successfully!")
+                .build();
+    }
+
+    @Override
+    public HasVotedResponse checkIfVoted(Long electionId, UserDetailsImpl currentUser){
+        boolean hasVoted = voteRepository.findByVoterIdAndElectionId(currentUser.getId(), electionId)
+                .isPresent();
+        return new HasVotedResponse(hasVoted);
+    }
+
+    @Override
+    @Transactional
+    public MessageResponse refractVote(Long electionId, UserDetailsImpl currentUser){
+        Election election = electionRepository.findById(electionId)
+                .orElseThrow(() -> new ResourceNotFoundException("Election not found with the id: " + electionId));
+
+        if(!election.isAllowRevote()){
+            throw new IllegalStateException("This election does not allow votes to be retracted.");
+        }
+
+        Vote vote = voteRepository.findByVoterIdAndElectionId(currentUser.getId(), electionId)
+                .orElseThrow(() -> new ResourceNotFoundException("No vote found to you in this election to retract."));
+
+        voteRepository.delete(vote);
+
+        return new MessageResponse("Your vote has been retracted successfully.");
+    }
+}


### PR DESCRIPTION
- Adds Vote entity with a unique constraint on voter and election to prevent duplicate votes.
- Implements VoteRepository, VoteService, and VoteController for the voting feature.
- Creates endpoints for casting a vote (POST /api/votes), checking a user's vote status (GET /api/votes/check/{id}), and retracting a vote (DELETE /api/votes/{id}).
- Implements business logic in the service layer to validate voter eligibility, election status (must be ACTIVE), and revote permissions.
- Secures all endpoints for USER role using @PreAuthorize and obtains the current user via @AuthenticationPrincipal for enhanced security.