### PR TITLE
feat(election): Implement public election results endpoint

### DIFF
--- a/src/main/java/com/abdulkhaleel/blockchain_voting/election/controller/ElectionController.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/election/controller/ElectionController.java
@@ -1,11 +1,13 @@
 package com.abdulkhaleel.blockchain_voting.election.controller;
 
 import com.abdulkhaleel.blockchain_voting.election.dto.CreateElectionRequest;
+import com.abdulkhaleel.blockchain_voting.election.dto.ElectionResultsResponse;
 import com.abdulkhaleel.blockchain_voting.election.dto.UpdateElectionRequest;
 import com.abdulkhaleel.blockchain_voting.election.model.Election;
 import com.abdulkhaleel.blockchain_voting.election.model.ElectionResponse;
 import com.abdulkhaleel.blockchain_voting.election.services.ElectionService;
 import com.abdulkhaleel.blockchain_voting.user.dto.MessageResponse;
+import com.abdulkhaleel.blockchain_voting.vote.service.VoteService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -23,6 +25,7 @@ import java.time.LocalDateTime;
 public class ElectionController {
 
     private final ElectionService electionService;
+    private final VoteService voteService;
 
     @PostMapping
     @PreAuthorize("hasRole('ADMIN')")
@@ -70,5 +73,11 @@ public class ElectionController {
                 .allowRevote(election.isAllowRevote())
                 .createdAt(election.getCreatedAt())
                 .build();
+    }
+
+    @GetMapping("/{electionId}/results")
+    public ResponseEntity<ElectionResultsResponse> getElectionResults(@PathVariable Long electionId){
+        ElectionResultsResponse results = voteService.getElectionResult(electionId);
+        return ResponseEntity.ok(results);
     }
 }

--- a/src/main/java/com/abdulkhaleel/blockchain_voting/election/dto/CandidateResultDto.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/election/dto/CandidateResultDto.java
@@ -1,0 +1,13 @@
+package com.abdulkhaleel.blockchain_voting.election.dto;
+
+import lombok.*;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CandidateResultDto {
+    private Long candidateId;
+    private String name;
+    private Long voteCount;
+}

--- a/src/main/java/com/abdulkhaleel/blockchain_voting/election/dto/ElectionResultsResponse.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/election/dto/ElectionResultsResponse.java
@@ -1,0 +1,22 @@
+package com.abdulkhaleel.blockchain_voting.election.dto;
+
+import com.abdulkhaleel.blockchain_voting.election.model.ElectionStatus;
+import lombok.*;
+import org.w3c.dom.stylesheets.LinkStyle;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ElectionResultsResponse {
+    private Long electionId;
+    private String name;
+    private ElectionStatus status;
+    private LocalDateTime startTime;
+    private LocalDate endTime;
+    private List<CandidateResultDto> results;
+}

--- a/src/main/java/com/abdulkhaleel/blockchain_voting/vote/dto/CandidateVoteCount.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/vote/dto/CandidateVoteCount.java
@@ -1,0 +1,11 @@
+package com.abdulkhaleel.blockchain_voting.vote.dto;
+
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CandidateVoteCount {
+    private Long candidateId;
+    private Long voteCount;
+}

--- a/src/main/java/com/abdulkhaleel/blockchain_voting/vote/repository/VoteRepository.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/vote/repository/VoteRepository.java
@@ -3,8 +3,17 @@ package com.abdulkhaleel.blockchain_voting.vote.repository;
 import com.abdulkhaleel.blockchain_voting.vote.model.Vote;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
+import com.abdulkhaleel.blockchain_voting.vote.dto.CandidateVoteCount;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface VoteRepository extends JpaRepository<Vote, Long> {
     Optional<Vote> findByVoterIdAndElectionId(Long voterId, Long electionId);
+
+    @Query("SELECT new com.abdulkhaleel.blockchain_voting.vote.dto.CandidateVoteCount(v.candidate.id, COUNT(v)) " +
+            "FROM Vote v WHERE v.election.id = :electionId GROUP BY v.candidate.id")
+    List<CandidateVoteCount> countVotesByElection(@Param("electionId") Long electionId);
+
 }

--- a/src/main/java/com/abdulkhaleel/blockchain_voting/vote/service/VoteService.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/vote/service/VoteService.java
@@ -1,5 +1,6 @@
 package com.abdulkhaleel.blockchain_voting.vote.service;
 
+import com.abdulkhaleel.blockchain_voting.election.dto.ElectionResultsResponse;
 import com.abdulkhaleel.blockchain_voting.security.services.UserDetailsImpl;
 import com.abdulkhaleel.blockchain_voting.user.dto.MessageResponse;
 import com.abdulkhaleel.blockchain_voting.vote.dto.CastVoteRequest;
@@ -10,4 +11,5 @@ public interface VoteService {
     VoteResponse castVote(CastVoteRequest castVoteRequest, UserDetailsImpl currentUser);
     HasVotedResponse checkIfVoted(Long electionId, UserDetailsImpl currentUser);
     MessageResponse refractVote(Long electionId, UserDetailsImpl currentUser);
+    ElectionResultsResponse getElectionResult(Long electionId);
 }


### PR DESCRIPTION
Adds a new public API endpoint GET /api/elections/{electionId}/results to display the vote tally for a given election.

- Creates  and  to provide a well-structured JSON response.
- Implements a new JPQL query in  using GROUP BY to efficiently count votes per candidate at the database level.
- Adds  logic to  to orchestrate fetching election data and vote counts, and to assemble the final DTO.
- Includes candidates with zero votes in the final results for complete transparency.
- The new controller method is added to  and is publicly accessible.