### PR TITLE
feat(blockchain): Implement final MVP feature for election anchoring

### DIFF
--- a/src/main/java/com/abdulkhaleel/blockchain_voting/blockchain/model/Block.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/blockchain/model/Block.java
@@ -1,0 +1,49 @@
+package com.abdulkhaleel.blockchain_voting.blockchain.model;
+
+import lombok.Getter;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+
+@Getter
+public class Block {
+
+    private final int index;
+    private final long timestamp;
+    private final String data;
+    private final String previousHash;
+    private final String hash;
+
+    public Block(int index, String data, String previousHash) {
+        this.index = index;
+        this.timestamp = Instant.now().toEpochMilli();
+        this.data = data;
+        this.previousHash = previousHash;
+        this.hash = this.calculateHash();
+    }
+
+    public String calculateHash() {
+        String valueToHash = this.index + Long.toString(this.timestamp) + this.data + this.previousHash;
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] encodedhash = digest.digest(valueToHash.getBytes(StandardCharsets.UTF_8));
+            return bytesToHex(encodedhash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 algorithm not found", e);
+        }
+    }
+
+    public String bytesToHex(byte[] hash){
+        StringBuilder hexString = new StringBuilder(2 * hash.length);
+        for(byte b: hash){
+            String hex = Integer.toHexString(0xff & b);
+            if(hex.length() == 1){
+                hexString.append('0');
+            }
+            hexString.append(hex);
+        }
+        return hexString.toString();
+    }
+}

--- a/src/main/java/com/abdulkhaleel/blockchain_voting/blockchain/service/BlockchainService.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/blockchain/service/BlockchainService.java
@@ -1,0 +1,62 @@
+package com.abdulkhaleel.blockchain_voting.blockchain.service;
+
+import com.abdulkhaleel.blockchain_voting.blockchain.model.Block;
+import jakarta.annotation.PostConstruct;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class BlockchainService {
+
+    private final List<Block> chain = new ArrayList<>();
+
+    @PostConstruct
+    private void init(){
+        Block genesisBlock = new Block(0, "Genesis Block", "0");
+        chain.add(genesisBlock);
+    }
+
+    public List<Block> getChain(){
+        return new ArrayList<>(chain);
+    }
+
+    public Block getLatestBlock(){
+        return chain.get(chain.size() - 1);
+    }
+
+    // In BlockchainService.java
+
+    public void addBlock(String data) {
+        // Get the last block in the chain to link the new one
+        Block previousBlock = getLatestBlock();
+
+        // The new block's index is one greater than the previous
+        int newIndex = previousBlock.getIndex() + 1;
+
+        // Create the new block, passing its index, data, and the HASH of the previous block
+        Block newBlock = new Block(newIndex, data, previousBlock.getHash());
+
+        // Perform a validation check before adding it to the chain
+        if (isNewBlockValid(newBlock, previousBlock)) {
+            chain.add(newBlock);
+        } else {
+            // If validation fails, throw a clear exception. This is what you are seeing.
+            throw new IllegalStateException("Attempted to add an invalid block to the chain.");
+        }
+    }
+
+    private boolean isNewBlockValid(Block newBlock, Block previousBlock) {
+        if (previousBlock.getIndex() + 1 != newBlock.getIndex()) {
+            return false; // Index is incorrect
+        }
+        if (!previousBlock.getHash().equals(newBlock.getPreviousHash())) {
+            return false; // Previous hash does not match
+        }
+        if (!newBlock.getHash().equals(newBlock.calculateHash())) {
+            return false; // Hash of the new block is invalid
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/abdulkhaleel/blockchain_voting/election/controller/ElectionController.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/election/controller/ElectionController.java
@@ -80,4 +80,11 @@ public class ElectionController {
         ElectionResultsResponse results = voteService.getElectionResult(electionId);
         return ResponseEntity.ok(results);
     }
+
+    @PostMapping("/{electionId}/complete")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ElectionResponse> completeAnchorElection(@PathVariable Long electionId){
+        ElectionResponse updatedElection = electionService.closeAndAnchorElection(electionId);
+        return ResponseEntity.ok(updatedElection);
+    }
 }

--- a/src/main/java/com/abdulkhaleel/blockchain_voting/election/model/Election.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/election/model/Election.java
@@ -54,4 +54,7 @@ public class Election {
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(name = "election_voters", joinColumns = @JoinColumn(name = "election_id"), inverseJoinColumns = @JoinColumn(name = "user_id"))
     private Set<User> eligibleVoters = new HashSet<>();
+
+    @Column(unique = true)
+    private String anchorHash;
 }

--- a/src/main/java/com/abdulkhaleel/blockchain_voting/election/model/ElectionResponse.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/election/model/ElectionResponse.java
@@ -16,6 +16,22 @@ public class ElectionResponse {
     private LocalDate endDate;
     private ElectionStatus status;
     private boolean isPublic;
+    private String anchorHash;
     private boolean allowRevote;
     private LocalDateTime createdAt;
+
+    public static ElectionResponse formEntity(Election election){
+        return ElectionResponse.builder()
+                .id(election.getId())
+                .title(election.getTitle())
+                .description(election.getDescription())
+                .startDate(election.getStartDate())
+                .endDate(election.getEndDate())
+                .status(election.getStatus())
+                .isPublic(election.isPublic())
+                .anchorHash(election.getAnchorHash())
+                .allowRevote(election.isAllowRevote())
+                .createdAt(election.getCreatedAt())
+                .build();
+    }
 }

--- a/src/main/java/com/abdulkhaleel/blockchain_voting/election/services/ElectionService.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/election/services/ElectionService.java
@@ -3,6 +3,7 @@ package com.abdulkhaleel.blockchain_voting.election.services;
 import com.abdulkhaleel.blockchain_voting.election.dto.CreateElectionRequest;
 import com.abdulkhaleel.blockchain_voting.election.dto.UpdateElectionRequest;
 import com.abdulkhaleel.blockchain_voting.election.model.Election;
+import com.abdulkhaleel.blockchain_voting.election.model.ElectionResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -12,4 +13,5 @@ public interface ElectionService {
     Election getElectionById(Long electionId);
     Election updateElection(Long electionId, UpdateElectionRequest request);
     void deleteElection(Long electionId);
+    ElectionResponse closeAndAnchorElection(Long electionId);
 }

--- a/src/main/java/com/abdulkhaleel/blockchain_voting/election/services/ElectionServiceImpl.java
+++ b/src/main/java/com/abdulkhaleel/blockchain_voting/election/services/ElectionServiceImpl.java
@@ -1,23 +1,36 @@
 package com.abdulkhaleel.blockchain_voting.election.services;
 
+import com.abdulkhaleel.blockchain_voting.blockchain.service.BlockchainService;
+import com.abdulkhaleel.blockchain_voting.candidate.repository.CandidateRepository;
+import com.abdulkhaleel.blockchain_voting.election.dto.CandidateResultDto;
 import com.abdulkhaleel.blockchain_voting.election.dto.CreateElectionRequest;
+import com.abdulkhaleel.blockchain_voting.election.dto.ElectionResultsResponse;
 import com.abdulkhaleel.blockchain_voting.election.dto.UpdateElectionRequest;
 import com.abdulkhaleel.blockchain_voting.election.model.Election;
+import com.abdulkhaleel.blockchain_voting.election.model.ElectionResponse;
 import com.abdulkhaleel.blockchain_voting.election.model.ElectionStatus;
 import com.abdulkhaleel.blockchain_voting.election.repository.ElectionRepository;
 import com.abdulkhaleel.blockchain_voting.exception.ResourceNotFoundException;
+import com.abdulkhaleel.blockchain_voting.vote.service.VoteService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Comparator;
 
 @Service
 @RequiredArgsConstructor
 public class ElectionServiceImpl implements ElectionService{
-
+    private final BlockchainService blockchainService;
+    private final VoteService voteService;
+    private final CandidateRepository candidateRepository;
     private final ElectionRepository electionRepository;
 
     @Override
@@ -70,6 +83,50 @@ public class ElectionServiceImpl implements ElectionService{
         }
         electionRepository.deleteById(electionId);
     }
+    @Override
+    @Transactional
+    public ElectionResponse closeAndAnchorElection(Long electionId){
+        Election election = getElectionById(electionId);
+        if(election.getStatus() == ElectionStatus.COMPLETED){
+            throw new IllegalStateException("Election is already closed and anchored.");
+        }
+        ElectionResultsResponse results = voteService.getElectionResult(electionId);
 
+        StringBuilder resultString = new StringBuilder();
 
+        resultString.append("electionId:").append(results.getElectionId()).append(";");
+        results.getResults().stream()
+                .sorted(Comparator.comparing(CandidateResultDto::getCandidateId))
+                .forEach(r -> resultString
+                        .append(r.getCandidateId()).append(";")
+                        .append(r.getVoteCount()).append(";"));
+
+        String resultsHash = createSha256Hash(resultString.toString());
+
+        blockchainService.addBlock(resultsHash);
+
+        election.setStatus(ElectionStatus.COMPLETED);
+        election.setAnchorHash(resultsHash);
+        Election savedElection = electionRepository.save(election);
+
+        return ElectionResponse.formEntity(election);
+    }
+
+    private String createSha256Hash(String input) {
+        try{
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] encodedHash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hexString = new StringBuilder(2 * encodedHash.length);
+            for(byte b: encodedHash){
+                String hex = Integer.toHexString(0xff & b);
+                if(hex.length() == 1){
+                    hexString.append('0');
+                }
+                hexString.append(hex);
+            }
+            return hexString.toString();
+        } catch (NoSuchAlgorithmException e){
+            throw new RuntimeException("Could not create hash ", e);
+        }
+    }
 }


### PR DESCRIPTION
This commit introduces the blockchain anchoring mechanism, completing the final requirement for the MVP.

- Implements an admin-only post-endpoint .
- When called, the service finalizes the election results, generates a deterministic SHA-256 hash of the tally, and creates a new block.
- A new  manages an in-memory, singleton blockchain, including a Genesis Block and basic validation.
- The immutable  class stores the results hash, linking it cryptographically to the previous block in the chain.
- The  entity is updated with the  and its status is set to , providing a permanent, tamper-evident seal for the election's outcome.
- The entire operation is wrapped in a transaction to ensure data integrity.